### PR TITLE
Add text_file_ext property to check_text

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -219,6 +219,10 @@ const TOOLS = [
                     type: "string",
                     description: "The text content to check with Vale",
                 },
+                text_file_ext: {
+                    type: "string",
+                    description: "Optional file extension for Vale to apply when checking the text (e.g., '.md', '.txt'). This can help Vale apply file format-specific rules if needed.",
+                },
                 config_path: {
                     type: "string",
                     description: "Optional path to .vale.ini file. If not provided, uses the server's configured path or searches in the current directory.",
@@ -355,8 +359,8 @@ See Vale documentation: https://vale.sh/docs/topics/packages/`,
                 };
             }
             case "check_text": {
-                const { text, config_path } = args;
-                debug(`check_text called - text length: ${text?.length}, config_path: ${config_path}`);
+                const { text, text_file_ext, config_path } = args;
+                debug(`check_text called - text length: ${text?.length}, text_file_ext: ${text_file_ext}, config_path: ${config_path}`);
                 if (!text) {
                     return {
                         content: [
@@ -377,7 +381,7 @@ See Vale documentation: https://vale.sh/docs/topics/packages/`,
                 // For check_text, we should use the provided config_path if given,
                 // otherwise fall back to the server's configured path since there's no file directory to search from
                 const effectiveConfigPath = config_path !== undefined ? config_path : valeConfigPath;
-                const result = await checkText(text, effectiveConfigPath);
+                const result = await checkText(text, text_file_ext, effectiveConfigPath);
                 debug(`check_text result - issues found: ${result.issues.length}, errors: ${result.summary.errors}, warnings: ${result.summary.warnings}, suggestions: ${result.summary.suggestions}`);
                 return {
                     content: [

--- a/build/vale-runner.d.ts
+++ b/build/vale-runner.d.ts
@@ -27,5 +27,5 @@ export declare function checkFile(filePath: string, configPath?: string): Promis
 /**
  * Runs Vale on text passed directly (via stdin)
  */
-export declare function checkText(text: string, configPath?: string): Promise<CheckFileResult>;
+export declare function checkText(text: string, textFileExt?: string, configPath?: string): Promise<CheckFileResult>;
 //# sourceMappingURL=vale-runner.d.ts.map

--- a/build/vale-runner.js
+++ b/build/vale-runner.js
@@ -281,9 +281,31 @@ export async function checkFile(filePath, configPath) {
 /**
  * Runs Vale on text passed directly (via stdin)
  */
-export async function checkText(text, configPath) {
-    // Build Vale command - just pass text via stdin
-    let command = `vale --output=JSON`;
+export async function checkText(text, textFileExt, configPath) {
+    // Check to see of any text was sent
+    if (!text || text.trim() === "") {
+        throw new Error(`No text found to check. Make sure the text has content that is not only whitespace.`);
+    }
+    // Now build the Vale command, starting with the command and adding arguments based on the parameters
+    let command = `vale`;
+    if (textFileExt) {
+        // Clean the provided file extension and
+        //  confirm it's in a valid format,
+        //  such as: "md", ".md", "txt", ".txt", or "docx"
+        let normalizedExt;
+        const trimmedExt = textFileExt.trim();
+        const extPattern = /^\.?[a-zA-Z0-9]+$/;
+        if (extPattern.test(trimmedExt)) {
+            // If a file extension is provided, we can use Vale's --ext flag to help it apply the correct rules
+            normalizedExt = trimmedExt.startsWith(".") ? trimmedExt : `.${trimmedExt}`;
+            command += ` --ext="${normalizedExt}"`;
+            console.error(`Using file extension for Vale: ${normalizedExt}`);
+        }
+        else {
+            // If the provided extension is not valid, throw an exception
+            throw new Error(`Vale doesn't allow a text file extension of: "${textFileExt}". Allowed format is an optional leading dot followed by letters and digits.`);
+        }
+    }
     if (configPath) {
         command += ` --config="${configPath}"`;
         console.error(`Using explicit config: ${configPath}`);
@@ -291,6 +313,8 @@ export async function checkText(text, configPath) {
     else {
         console.error(`Using Vale defaults or searching for config from current directory`);
     }
+    // add output argument to command
+    command += ` --output=JSON`;
     // Execute Vale with text as stdin
     const execOptions = {
         encoding: 'utf-8',

--- a/readme.md
+++ b/readme.md
@@ -284,7 +284,7 @@ Once configured, you can ask your AI assistant to:
 
 ## Available tools
 
-The server provides three MCP tools:
+The server provides four MCP tools:
 
 ### `vale_status`
 
@@ -342,6 +342,29 @@ Lint a file at a specific path against Vale style rules.
 **Example usage in AI:**
 
 > "Check the README.md file for style issues"
+
+### `check_text`
+
+Lint AI-generated text against Vale style rules before it's written to a file or artifact.
+
+**Parameters:**
+
+- `text` (required): The text content to check with Vale
+- `text_file_ext` (optional): The file extension to apply to the text.
+    Used as the value to Vale's `--ext` argument.
+    If not specified, the `--ext` argument is not used.
+    The format for this value is an optional leading dot followed by letters and digits,
+    such as: "md", ".md", "txt", ".txt", or "docx"
+- `config_path` (optional): The path to the config file to use.
+    If not specified, the server's configured path is used.
+
+**Returns:**
+
+- A JSON object containing Vale's evaluation results.
+
+**Example usage in AI:**
+
+> "Check this text for style issues"
 
 ## Command-line options
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -257,6 +257,10 @@ const TOOLS: Tool[] = [
           type: "string",
           description: "The text content to check with Vale",
         },
+        text_file_ext: {
+          type: "string",
+          description: "Optional file extension for Vale to apply when checking the text (e.g., '.md', '.txt'). This can help Vale apply file format-specific rules if needed.",
+        },
         config_path: {
           type: "string",
           description: "Optional path to .vale.ini file. If not provided, uses the server's configured path or searches in the current directory.",
@@ -412,9 +416,9 @@ See Vale documentation: https://vale.sh/docs/topics/packages/`,
       }
 
       case "check_text": {
-        const { text, config_path } = args as { text: string; config_path?: string };
+        const { text, text_file_ext, config_path } = args as { text: string; text_file_ext?: string; config_path?: string };
 
-        debug(`check_text called - text length: ${text?.length}, config_path: ${config_path}`);
+        debug(`check_text called - text length: ${text?.length}, text_file_ext: ${text_file_ext}, config_path: ${config_path}`);
 
         if (!text) {
           return {
@@ -439,7 +443,7 @@ See Vale documentation: https://vale.sh/docs/topics/packages/`,
         // otherwise fall back to the server's configured path since there's no file directory to search from
         const effectiveConfigPath = config_path !== undefined ? config_path : valeConfigPath;
 
-        const result = await checkText(text, effectiveConfigPath);
+        const result = await checkText(text, text_file_ext, effectiveConfigPath);
 
         debug(`check_text result - issues found: ${result.issues.length}, errors: ${result.summary.errors}, warnings: ${result.summary.warnings}, suggestions: ${result.summary.suggestions}`);
 

--- a/src/vale-runner.ts
+++ b/src/vale-runner.ts
@@ -341,18 +341,42 @@ export async function checkFile(
  */
 export async function checkText(
   text: string,
+  textFileExt?: string,
   configPath?: string
 ): Promise<CheckFileResult> {
-  // Build Vale command - just pass text via stdin
-  let command = `vale --output=JSON`;
-
+  // Check to see of any text was sent
+  if (!text || text.trim() === "") {
+    throw new Error(`No text found to check. Make sure the text has content that is not only whitespace.`);
+  }
+  // Now build the Vale command, starting with the command and adding arguments based on the parameters
+  let command = `vale`;
+  if (textFileExt) {
+    // Clean the provided file extension and
+    //  confirm it's in a valid format,
+    //  such as: "md", ".md", "txt", ".txt", or "docx"
+    let normalizedExt: string | undefined;
+    const trimmedExt = textFileExt.trim();
+    const extPattern = /^\.?[a-zA-Z0-9]+$/;
+    if (extPattern.test(trimmedExt)) {
+      // If a file extension is provided, we can use Vale's --ext flag to help it apply the correct rules
+      normalizedExt = trimmedExt.startsWith(".") ? trimmedExt : `.${trimmedExt}`;
+      command += ` --ext="${normalizedExt}"`;
+      console.error(`Using file extension for Vale: ${normalizedExt}`);
+    } else {
+      // If the provided extension is not valid, throw an exception
+      throw new Error(`Vale doesn't allow a text file extension of: "${textFileExt}". Allowed format is an optional leading dot followed by letters and digits.`
+      );
+    }
+  }
   if (configPath) {
     command += ` --config="${configPath}"`;
     console.error(`Using explicit config: ${configPath}`);
   } else {
     console.error(`Using Vale defaults or searching for config from current directory`);
   }
-
+  // add output argument to command
+  command += ` --output=JSON`;
+  
   // Execute Vale with text as stdin
   const execOptions: ExecOptions = {
     encoding: 'utf-8',


### PR DESCRIPTION
Adds the `text_file_ext` property to the `check_text` tool to allow the AI to specify the file type of the text that it is sending to Vale. This property value is passed to the Vale command as the `--ext` argument.

Updates the `readme.md` to document the `check_text` tool, including the new property.